### PR TITLE
Allow databases to specify a connection string if necessary

### DIFF
--- a/apps/trade/trade_application.py
+++ b/apps/trade/trade_application.py
@@ -31,7 +31,7 @@ class TradeApplication(object):
       self.order_matcher_disabled = True
 
     from models import Base, db_bootstrap
-    db_engine = options.sqlalchemy_engine + ':///' + \
+    db_engine = options.sqlalchemy_engine + '://' + \
                 os.path.expanduser(options.sqlalchemy_connection_string)
     engine = create_engine( db_engine, echo=options.db_echo)
     Base.metadata.create_all(engine)

--- a/apps/ws_gateway/main.py
+++ b/apps/ws_gateway/main.py
@@ -510,7 +510,7 @@ class WebSocketGatewayApplication(tornado.web.Application):
         self.update_tor_nodes()
 
         from models import Base, db_bootstrap
-        db_engine = self.options.sqlalchemy_engine + ':///' +\
+        db_engine = self.options.sqlalchemy_engine + '://' +\
                     os.path.expanduser(self.options.sqlalchemy_connection_string)
         engine = create_engine( db_engine, echo=self.options.db_echo)
         Base.metadata.create_all(engine)

--- a/config/bootstrap/bootstrap.py
+++ b/config/bootstrap/bootstrap.py
@@ -21,7 +21,7 @@ def main():
   config.read( candidates )
 
   from trade.models import Base, Currency, Instrument, User, Broker, DepositMethods
-  db_engine = config.get('database','sqlalchemy_engine') + ':///' + os.path.expanduser(config.get('database','sqlalchemy_connection_string'))
+  db_engine = config.get('database','sqlalchemy_engine') + '://' + os.path.expanduser(config.get('database','sqlalchemy_connection_string'))
   engine = create_engine( db_engine, echo=True)
   #engine.raw_connection().connection.text_factory = str
 


### PR DESCRIPTION
`os.path.expanduser` already makes sure there's a leading / on paths it expands, so the third one isn't necessary and inhibits the use of other databases that need to specify a username:password@host:port in their connection string.